### PR TITLE
Chore/#54 각 account 별 main.tf 주석 추가

### DIFF
--- a/management-team-account/monitoring/main.tf
+++ b/management-team-account/monitoring/main.tf
@@ -1,3 +1,4 @@
+# management account
 terraform {
   required_version = ">= 1.1.0"
   required_providers {

--- a/modules/eventbridge_triggers/main.tf
+++ b/modules/eventbridge_triggers/main.tf
@@ -1,4 +1,3 @@
-# management account
 resource "aws_cloudwatch_event_rule" "s3_object_created" {
   name        = "cloudtrail-s3-event-rule"
   description = "Trigger Lambda on CloudTrail S3 delivery objects"


### PR DESCRIPTION
## #️⃣ Related Issues

#54 

## 📝 Work Summary

main 브랜치에서 terraform apply를 다시 돌리기 위해, management account와 operation account의 main.tf에 주석을 추가하였습니다.